### PR TITLE
fix CI env var causing fail build for react app

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -16,7 +16,7 @@ jobs:
 
     strategy:
       matrix:
-        node-version: [12.x, 14.x, 16.x]
+        node-version: [ 16.x ]
         # See supported Node.js release schedule at https://nodejs.org/en/about/releases/
 
     steps:
@@ -27,6 +27,6 @@ jobs:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
     - name: odp-reactor-browser build test
-      run: yarn install && yarn test -- --watchAll=false && yarn build && yarn test -- --watchAll=false
+      run: yarn install && yarn test -- --watchAll=false && CI='' yarn build && yarn test -- --watchAll=false
 
 


### PR DESCRIPTION
we also remove node version 12 and 14 to speed up the build process